### PR TITLE
Adding Firefox extension

### DIFF
--- a/browser-extension/firefox/manifest.json
+++ b/browser-extension/firefox/manifest.json
@@ -1,0 +1,19 @@
+{
+
+    "manifest_version": 2,
+    "name": "set-time-in-header",
+    "version": "1.0",
+  
+    "content_scripts": [
+      {
+        "matches": [
+            "https://meet.google.com/*",
+            "https://*.zoom.us/*",
+            "https://teams.microsoft.com/*"
+          ],
+        "js": ["set-time-in-header.js"]
+      }
+    ]
+  
+  }
+  

--- a/browser-extension/firefox/set-time-in-header.js
+++ b/browser-extension/firefox/set-time-in-header.js
@@ -1,0 +1,9 @@
+function timeString(now) {
+    return now.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
+}
+
+function updateTitle() {
+    window.document.title = timeString(new Date());
+}
+
+setInterval(updateTitle, 1000);


### PR DESCRIPTION
To automatically convert the URL link that opens the meeting from the browser into a timer clock